### PR TITLE
[Chartboost] Hold activity weak reference in rewarded adapter and sdk update

### DIFF
--- a/Chartboost/build.gradle
+++ b/Chartboost/build.gradle
@@ -1,4 +1,4 @@
-project.version = '8.0.2.1'
+project.version = '8.0.3.2'
 project.ext.networkName = 'chartboost'
 
 apply from: '../shared-build.gradle'

--- a/Chartboost/src/main/java/com/mopub/mobileads/ChartboostRewardedVideo.java
+++ b/Chartboost/src/main/java/com/mopub/mobileads/ChartboostRewardedVideo.java
@@ -12,6 +12,7 @@ import com.mopub.common.LifecycleListener;
 import com.mopub.common.MediationSettings;
 import com.mopub.common.logging.MoPubLog;
 
+import java.lang.ref.WeakReference;
 import java.util.Map;
 
 import static com.mopub.common.logging.MoPubLog.AdapterLogEvent.CUSTOM;
@@ -36,6 +37,11 @@ public class ChartboostRewardedVideo extends CustomEventRewardedVideo {
 
     @NonNull
     private ChartboostAdapterConfiguration mChartboostAdapterConfiguration;
+
+    /**
+     * A Weak reference of the activity used to show the Chartboost Rewarded Ad
+     */
+    private WeakReference<Activity> mWeakActivity;
 
     public ChartboostRewardedVideo() {
         mHandler = new Handler();
@@ -77,6 +83,8 @@ public class ChartboostRewardedVideo extends CustomEventRewardedVideo {
     protected void loadWithSdkInitialized(@NonNull Activity activity,
                                           @NonNull Map<String, Object> localExtras, @NonNull Map<String, String> serverExtras)
             throws Exception {
+
+        mWeakActivity = new WeakReference<>(activity);
 
         // Chartboost delegation can be set to null on some cases in Chartboost SDK 8.0+.
         // We should set the delegation on each load request to prevent this.
@@ -136,7 +144,7 @@ public class ChartboostRewardedVideo extends CustomEventRewardedVideo {
     public void showVideo() {
         MoPubLog.log(getAdNetworkId(), SHOW_ATTEMPTED, ADAPTER_NAME);
 
-        if (hasVideoAvailable()) {
+        if (hasVideoAvailable() && mWeakActivity != null && mWeakActivity.get() != null) {
             Chartboost.showRewardedVideo(mLocation);
         } else {
             MoPubRewardedVideoManager.onRewardedVideoPlaybackError(

--- a/Chartboost/src/main/java/com/mopub/mobileads/ChartboostShared.java
+++ b/Chartboost/src/main/java/com/mopub/mobileads/ChartboostShared.java
@@ -17,7 +17,6 @@ import com.mopub.common.logging.MoPubLog;
 import com.mopub.common.privacy.ConsentStatus;
 import com.mopub.common.privacy.PersonalInfoManager;
 import com.mopub.mobileads.CustomEventInterstitial.CustomEventInterstitialListener;
-import com.mopub.mobileads.chartboost.BuildConfig;
 
 import java.util.Collections;
 import java.util.Map;


### PR DESCRIPTION
We discovered that rewarded ads in Chartboost adapter were throwing an error. 

com.chartboost.sdk.sample.cbtest I/MoPub: [com.mopub.mobileads.MoPubRewardedVideoManager][onAdSuccess] SDK Log - Could not load custom event because Activity reference was null. Call MoPub#updateActivity before requesting more rewarded ads.

To fix it I followed common pattern from other adapters to hold activity weak reference and check it before playing rewarded video. 

**Chartboost SDK 8.0.3 changes:**

- Increase WEB_VIEW_PAGE_LOAD_TIMEOUT timeout from 3 to 15 seconds to give more time for ads to load, especially on the first try. This was causing issues where sdk could be stuck and never recover its state. 

- Fix callback issue for Android 4. Not supported devices weren't sending any callback which could lead to increased latency for mediations.

- SDK was not able to recover its state after the device suffered from no connectivity state. This caused increased latency and removed the possibility to display ads until the app was restarted.