### PR TITLE
Release 8.2.0

### DIFF
--- a/Chartboost/build.gradle
+++ b/Chartboost/build.gradle
@@ -1,4 +1,4 @@
-project.version = '8.1.0.2'
+project.version = '8.2.0.0'
 project.ext.networkName = 'chartboost'
 
 apply from: '../shared-build.gradle'

--- a/Chartboost/src/main/java/com/mopub/mobileads/ChartboostAdapterConfiguration.java
+++ b/Chartboost/src/main/java/com/mopub/mobileads/ChartboostAdapterConfiguration.java
@@ -24,10 +24,6 @@ public class ChartboostAdapterConfiguration extends BaseAdapterConfiguration {
 
     private static volatile ChartboostShared.ChartboostSingletonDelegate sDelegate = new ChartboostShared.ChartboostSingletonDelegate();
 
-    // Chartboost's keys
-    private static final String APP_ID_KEY = "appId";
-    private static final String APP_SIGNATURE_KEY = "appSignature";
-
     // Adapter's keys
     private static final String ADAPTER_NAME = ChartboostAdapterConfiguration.class.getSimpleName();
     private static final String ADAPTER_VERSION = BuildConfig.VERSION_NAME;
@@ -76,29 +72,7 @@ public class ChartboostAdapterConfiguration extends BaseAdapterConfiguration {
         synchronized (ChartboostAdapterConfiguration.class) {
             try {
                 if (configuration != null && !configuration.isEmpty()) {
-
-                    boolean isInitialized = ChartboostShared.initializeSdk(context, configuration);
-
-                    final String appId = configuration.get(APP_ID_KEY);
-                    final String appSignature = configuration.get(APP_SIGNATURE_KEY);
-
-                    if (TextUtils.isEmpty(appId) || TextUtils.isEmpty(appSignature)) {
-                        MoPubLog.log(CUSTOM, ADAPTER_NAME, "Chartboost's initialization " +
-                                "succeeded, but unable to call Chartboost's startWithAppId(). " +
-                                "Ensure Chartboost's " + APP_ID_KEY + " and " + APP_SIGNATURE_KEY +
-                                "are populated on the MoPub dashboard. Note that initialization on " +
-                                "the first app launch is a no-op.");
-                    } else {
-                        // Add this check to avoid double initialization of Chartboost SDK
-                        // which leads to double config and install network requests
-                        if(!isInitialized) {
-                            Chartboost.startWithAppId(context, appId, appSignature);
-                        }
-                    }
-
-                    Chartboost.setMediation(Chartboost.CBMediation.CBMediationMoPub, MoPub.SDK_VERSION, BuildConfig.VERSION_NAME);
-                    Chartboost.setDelegate(sDelegate);
-                    Chartboost.setAutoCacheAds(false);
+                    ChartboostShared.initializeSdk(context, configuration);
                     networkInitializationSucceeded = true;
                 } else {
                     MoPubLog.log(CUSTOM, ADAPTER_NAME, "Chartboost's initialization via " +

--- a/Chartboost/src/main/java/com/mopub/mobileads/ChartboostAdapterConfiguration.java
+++ b/Chartboost/src/main/java/com/mopub/mobileads/ChartboostAdapterConfiguration.java
@@ -77,7 +77,7 @@ public class ChartboostAdapterConfiguration extends BaseAdapterConfiguration {
             try {
                 if (configuration != null && !configuration.isEmpty()) {
 
-                    ChartboostShared.initializeSdk(context, configuration);
+                    boolean isInitialized = ChartboostShared.initializeSdk(context, configuration);
 
                     final String appId = configuration.get(APP_ID_KEY);
                     final String appSignature = configuration.get(APP_SIGNATURE_KEY);
@@ -89,7 +89,11 @@ public class ChartboostAdapterConfiguration extends BaseAdapterConfiguration {
                                 "are populated on the MoPub dashboard. Note that initialization on " +
                                 "the first app launch is a no-op.");
                     } else {
-                        Chartboost.startWithAppId(context, appId, appSignature);
+                        // Add this check to avoid double initialization of Chartboost SDK
+                        // which leads to double config and install network requests
+                        if(!isInitialized) {
+                            Chartboost.startWithAppId(context, appId, appSignature);
+                        }
                     }
 
                     Chartboost.setMediation(Chartboost.CBMediation.CBMediationMoPub, MoPub.SDK_VERSION, BuildConfig.VERSION_NAME);

--- a/Chartboost/src/main/java/com/mopub/mobileads/ChartboostShared.java
+++ b/Chartboost/src/main/java/com/mopub/mobileads/ChartboostShared.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.chartboost.sdk.Chartboost;
 import com.chartboost.sdk.ChartboostDelegate;
@@ -51,11 +50,6 @@ public class ChartboostShared {
     private static final String APP_ID_KEY = "appId";
     private static final String APP_SIGNATURE_KEY = "appSignature";
     private static final String ADAPTER_NAME = ChartboostShared.class.getSimpleName();
-
-    @Nullable
-    private static String mAppId;
-    @Nullable
-    private static String mAppSignature;
 
     /**
      * Initialize the Chartboost SDK for the provided application id and app signature.
@@ -107,11 +101,16 @@ public class ChartboostShared {
         final String appId = serverExtras.get(APP_ID_KEY);
         final String appSignature = serverExtras.get(APP_SIGNATURE_KEY);
 
-        mAppId = appId;
-        mAppSignature = appSignature;
+        if(appId.isEmpty() || appSignature.isEmpty()) {
+            MoPubLog.log(CUSTOM, ADAPTER_NAME, "Chartboost's initialization " +
+                    "succeeded, but unable to call Chartboost's startWithAppId(). " +
+                    "Ensure Chartboost's " + APP_ID_KEY + " and " + APP_SIGNATURE_KEY +
+                    "are populated on the MoPub dashboard. Note that initialization on " +
+                    "the first app launch is a no-op.");
+        }
 
         // Perform all the common SDK initialization steps including startAppWithId
-        Chartboost.startWithAppId(context, mAppId, mAppSignature);
+        Chartboost.startWithAppId(context, appId, appSignature);
         Chartboost.setMediation(Chartboost.CBMediation.CBMediationMoPub, MoPub.SDK_VERSION,
                 new ChartboostAdapterConfiguration().getAdapterVersion());
         Chartboost.setDelegate(sDelegate);
@@ -518,7 +517,5 @@ public class ChartboostShared {
     static void reset() {
         // Clears all the locations to load and other state.
         sDelegate = new ChartboostSingletonDelegate();
-        mAppId = null;
-        mAppSignature = null;
     }
 }

--- a/Chartboost/src/main/java/com/mopub/mobileads/ChartboostShared.java
+++ b/Chartboost/src/main/java/com/mopub/mobileads/ChartboostShared.java
@@ -62,6 +62,10 @@ public class ChartboostShared {
      */
     public static synchronized boolean initializeSdk(@NonNull Context context,
                                                      @NonNull Map<String, String> serverExtras) {
+        if(Chartboost.isSdkStarted()) {
+            return false;
+        }
+
         Preconditions.checkNotNull(context);
         Preconditions.checkNotNull(serverExtras);
 
@@ -102,13 +106,6 @@ public class ChartboostShared {
 
         final String appId = serverExtras.get(APP_ID_KEY);
         final String appSignature = serverExtras.get(APP_SIGNATURE_KEY);
-
-        if (!TextUtils.isEmpty(appId) && !TextUtils.isEmpty(appSignature)) {
-            if (appId.equals(mAppId) && appSignature.equals(mAppSignature)) {
-                // We don't need to reinitialize.
-                return false;
-            }
-        }
 
         mAppId = appId;
         mAppSignature = appSignature;


### PR DESCRIPTION
- Update Chartboost SDK to version 8.2.0
- Update adapter to version 8.2.0.0
- Fix double initialisation of the SDK which was causing double config and install requests 

**Chartboost 8.2.0 Release notes** 
Improvements:
- Added `adID` to events passed in banner ad delegate methods and to errors passed in load failure delegate methods for other ad types.
It uniquely identifies an ad. It might help when working with Chartboost to identify faulty creatives
- Sdk is compatible with Android api level 29. 

Fixes:
- Fixed crash while trying to download assets in some cases
- Fixed issue that in some cases caused banners to crash in Android 4.4.4
- Fixed banner crash upon banner click in certain conditions